### PR TITLE
Remove wrong "main" and default to root index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "objectorarray",
   "version": "1.0.4",
   "description": "Is the value an object or an array but not null?",
-  "main": "dist/index.js",
   "scripts": {
     "test": "tape test.js"
   },


### PR DESCRIPTION
The `dist/index.js` file does not exist anymore since commit 55b91fdb7080bb4e077fed9d682462daa395ef6a (between v1.0.2 and v1.0.4).
The `"main"` field should be removed here so that the `index.js` file at root is used instead, as the [default value](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#main).

Fix #3 : _error during rollup compilation or warning since Node.js 16_