### PR TITLE
Correcting the path to the file index.js for NodeJS 16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "objectorarray",
   "version": "1.0.4",
   "description": "Is the value an object or an array but not null?",
-  "main": "dist/index.js",
+  "main": "index.js",
   "scripts": {
     "test": "tape test.js"
   },


### PR DESCRIPTION
**DEP0128: modules with an invalid main entry and an index.js file**

Modules that have an invalid main entry (e.g., ./does-not-exist.js) and also have an index.js file in the top level directory will resolve the index.js file. That is deprecated and is going to throw an error in future Node.js versions.

Maybe v1.0.5 plugin?